### PR TITLE
feat: オフライン同期基盤と即入力 UI を追加

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,41 @@
+﻿# Codexエージェント運用ルール
+
+## 1. 役割と目標 `[docs/01_requirements.md]`
+- プロダクト名は「楽勘主義」。推し活支出を月次/年次で可視化する個人向け家計簿を維持し、手動入力を通じて支出実感を保つ。
+- ユーザーは単一想定だが最大数千人規模まで視野に入れる。複数カード/口座の支出を統合表示し、収入管理は対象外。
+- MVPでは手動入力高速化、カテゴリ（推し別など）による均等按分、月次/年次サマリと可視化、検索フィルタ、マルチカード統合を死守し、外部API連携やエクスポートは将来拡張扱い。
+
+## 2. 技術スタックと設計原則 `[docs/02_architecture.md]`
+- フロントは React + Vite + PWA（Service Worker / Background Sync）+ Zustand + Recharts を前提とし、オフライン即時入力→オンライン自動同期を基本とする。
+- ローカル永続は IndexedDB + Dexie、サーバは Supabase (PostgreSQL, Auth, PostgREST/Edge Functions)。秘匿鍵はクライアントに置かず、Cloudflare Pages 環境変数で管理。
+- アーキテクチャはローカル書き込み優先、最新勝ちで整合性確保、UI/状態/データアクセスの層分離を崩さない。
+
+## 3. データモデルと同期方針 `[docs/03_databese.md][docs/06_Non-functionalRequirements.md]`
+- コアテーブルは `users`, `accounts`, `categories`, `transactions`, `transaction_splits`, `user_settings`, `sync_state`。`transactions` は金額整数JPY、論理削除 `is_deleted`。`transaction_splits` でカテゴリ按分（均等 or 比率）。
+- クライアントも同スキーマを IndexedDB にミラー。UUID を事前採番し、`updated_at` を用いた最新勝ち戦略で同期。
+- 書き込みはローカルに即保存→同期キュー→オンライン時POST。失敗時は指数バックオフで再試行し、キューは7日保持。`If-Unmodified-Since` と `Idempotency-Key` を活用して整合性を守る。
+
+## 4. API利用ルール `[docs/04_api_v1.md]`
+- Base URL は `/v1`。Supabase JWT を `Authorization: Bearer` で送る。JSON, ISO8601, 金額整数JPYが基本規約。
+- `GET /accounts|categories|transactions` 等は絞り込み/ソート/カーソルページング対応。取引作成時はカテゴリ配列または比率配列を送信し、端数処理は最後のスプリットで調整。
+- 更新系は `If-Unmodified-Since`、作成は `Idempotency-Key` を推奨。削除は論理削除（`is_deleted=true`）を徹底。
+
+## 5. UX・非機能要件 `[docs/05_ScreenFlowDiagram.md][docs/06_Non-functionalRequirements.md]`
+- 主要画面フロー（即入力→一覧→レポート）とショートカット (`N`, `Enter`, `/`) を尊重し、PWAでモバイル片手操作最適化＆PCで集計閲覧を両立。
+- パフォーマンス目標: 初期表示 LCP < 2.5s, TTI < 1.5s, 主要操作 100ms、初回バンドル < 200KB gzip。リストは50件表示/200件で仮想化。60fpsスクロールを維持。
+- アクセシビリティ: WCAG AA相当のコントラスト、フォーカスリング常時可視、フォームARIA整備、トーストはライブルージョンで通知。
+
+## 6. セキュリティ・運用ポリシー `[docs/06_Non-functionalRequirements.md][docs/07_operation-Security.md]`
+- 認証は Supabase Auth。許可メール（現状 `kikun_dev@gmail.com`）のみ招待制ログイン。全テーブルに RLS `user_id = auth.uid()` を適用。
+- 通信は HTTPS。Supabase 側はマネージド暗号化。ローカル IndexedDB は平文保持なため、アプリPINロック（起動/復帰/無操作）と OS ロックを推奨。PINはBKDF2+ソルトでハッシュ保管し、連続誤入力時は短時間ロックアウト。
+- サービスロールキーはサーバ限定。Cloudflare Pages の環境変数で `SUPABASE_URL` と `SUPABASE_ANON_KEY` を管理。キー漏洩時は即ローテーション。
+- バックアップは月次手動エクスポート (SQL/CSV)。復旧はエクスポートからの限定インポート、または端末再ログインでサーバ正本を同期。IndexedDB破損時は再初期化→同期復旧。
+- ログは基本ローカルのみ。重大エラー時に匿名化して Sentry を有効化可。障害時は影響範囲特定→該当セッション停止→バックアップ確認→再発防止メモ。
+
+## 7. 開発プロセス・リリース管理 `[docs/07_operation-Security.md][docs/06_Non-functionalRequirements.md]`
+- ブランチ運用は `main` / `dev`。SemVer でタグ付けし、Cloudflare Pages でPRプレビューを確認。
+- `db/migrations` でスキーマ管理し、破壊的変更は避ける。リリース後は直前ビルドへ即ロールバック可能な状態を維持。
+- 依存は月次で更新確認し、Dependabot / `npm audit` を活用。CIではビルド・Lint・最小テストを実行し、テストは入力保存・フィルタ・オフライン同期などの主要シナリオを網羅。
+
+---
+これらは Codex エージェントが提案・実装・レビューを行う際のベースラインとする。逸脱が必要な場合は根拠と対応策を明示したうえで合意を取る。

--- a/db/migrations/0001_init.sql
+++ b/db/migrations/0001_init.sql
@@ -1,0 +1,219 @@
+-- === Extensions ===
+create extension if not exists "pgcrypto"; -- gen_random_uuid()
+
+-- === Common helpers ===
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end $$;
+
+-- user_id を未指定 INSERT 時に auth.uid() を自動補完（NULL のときだけ）
+create or replace function public.ensure_user_id()
+returns trigger language plpgsql as $$
+begin
+  if new.user_id is null then
+    new.user_id := auth.uid();
+  end if;
+  return new;
+end $$;
+
+-- === Tables ===
+-- すべての user_id は auth.users(id) に紐づく（Supabase標準のユーザー）
+create table if not exists public.accounts (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  name       text not null,
+  type       text not null check (type in ('credit','debit','cash','other')),
+  is_active  boolean not null default true,
+  sort_order int not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists idx_accounts_user on public.accounts(user_id);
+create trigger tg_accounts_updated before update on public.accounts
+  for each row execute function public.set_updated_at();
+create trigger tg_accounts_ensure_uid before insert on public.accounts
+  for each row execute function public.ensure_user_id();
+
+create table if not exists public.categories (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  name       text not null,
+  color      text,
+  is_builtin boolean not null default false,
+  is_active  boolean not null default true,
+  sort_order int not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(user_id, name)
+);
+create index if not exists idx_categories_user on public.categories(user_id);
+create trigger tg_categories_updated before update on public.categories
+  for each row execute function public.set_updated_at();
+create trigger tg_categories_ensure_uid before insert on public.categories
+  for each row execute function public.ensure_user_id();
+
+create table if not exists public.transactions (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  account_id uuid not null references public.accounts(id) on delete restrict,
+  amount     integer not null check (amount > 0), -- 円（整数）
+  memo       text,
+  occurred_at date not null,
+  is_deleted boolean not null default false,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+create index if not exists idx_tx_user_date on public.transactions(user_id, occurred_at desc);
+create index if not exists idx_tx_account on public.transactions(account_id);
+create index if not exists idx_tx_updated on public.transactions(user_id, updated_at);
+create trigger tg_tx_updated before update on public.transactions
+  for each row execute function public.set_updated_at();
+create trigger tg_tx_ensure_uid before insert on public.transactions
+  for each row execute function public.ensure_user_id();
+
+create table if not exists public.transaction_splits (
+  id             uuid primary key default gen_random_uuid(),
+  transaction_id uuid not null references public.transactions(id) on delete cascade,
+  category_id    uuid not null references public.categories(id) on delete restrict,
+  ratio          numeric(5,4) not null default 1.0 check (ratio > 0 and ratio <= 1),
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  unique(transaction_id, category_id)
+);
+create index if not exists idx_splits_tx on public.transaction_splits(transaction_id);
+create index if not exists idx_splits_cat on public.transaction_splits(category_id);
+create trigger tg_splits_updated before update on public.transaction_splits
+  for each row execute function public.set_updated_at();
+
+create table if not exists public.user_settings (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  currency   text not null default 'JPY',
+  decimals   smallint not null default 0,
+  theme      text default 'system', -- 'light' | 'dark' | 'system'
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create trigger tg_user_settings_updated before update on public.user_settings
+  for each row execute function public.set_updated_at();
+create trigger tg_user_settings_ensure_uid before insert on public.user_settings
+  for each row execute function public.ensure_user_id();
+
+-- （任意）同期カーソル
+create table if not exists public.sync_state (
+  id           uuid primary key default gen_random_uuid(),
+  user_id      uuid not null references auth.users(id) on delete cascade,
+  entity       text not null,
+  last_synced_at timestamptz,
+  updated_at   timestamptz not null default now(),
+  unique(user_id, entity)
+);
+create trigger tg_sync_state_updated before update on public.sync_state
+  for each row execute function public.set_updated_at();
+create trigger tg_sync_state_ensure_uid before insert on public.sync_state
+  for each row execute function public.ensure_user_id();
+
+-- === View（表示用：スプリットの金額計算はビューで提供） ===
+create or replace view public.v_transaction_splits as
+select
+  s.*,
+  (floor(s.ratio * t.amount))::int as amount_calc
+from public.transaction_splits s
+join public.transactions t on t.id = s.transaction_id;
+
+-- === RLS（Row Level Security） ===
+alter table public.accounts            enable row level security;
+alter table public.categories          enable row level security;
+alter table public.transactions        enable row level security;
+alter table public.transaction_splits  enable row level security;
+alter table public.user_settings       enable row level security;
+alter table public.sync_state          enable row level security;
+
+-- 自分の行のみ SELECT/INSERT/UPDATE/DELETE 可能（accounts/categories/transactions/user_settings/sync_state）
+create policy "select_own_accounts" on public.accounts
+  for select using (user_id = auth.uid());
+create policy "insert_own_accounts" on public.accounts
+  for insert with check (user_id = auth.uid());
+create policy "update_own_accounts" on public.accounts
+  for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+create policy "delete_own_accounts" on public.accounts
+  for delete using (user_id = auth.uid());
+
+create policy "select_own_categories" on public.categories
+  for select using (user_id = auth.uid());
+create policy "insert_own_categories" on public.categories
+  for insert with check (user_id = auth.uid());
+create policy "update_own_categories" on public.categories
+  for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+create policy "delete_own_categories" on public.categories
+  for delete using (user_id = auth.uid());
+
+-- transactions: account_id も自分のものに限定
+create policy "select_own_transactions" on public.transactions
+  for select using (user_id = auth.uid());
+create policy "insert_own_transactions" on public.transactions
+  for insert with check (
+    user_id = auth.uid()
+    and exists (select 1 from public.accounts a where a.id = account_id and a.user_id = auth.uid())
+  );
+create policy "update_own_transactions" on public.transactions
+  for update using (user_id = auth.uid()) with check (
+    user_id = auth.uid()
+    and exists (select 1 from public.accounts a where a.id = account_id and a.user_id = auth.uid())
+  );
+create policy "delete_own_transactions" on public.transactions
+  for delete using (user_id = auth.uid());
+
+-- transaction_splits: 紐づく取引・カテゴリが自分のものに限定
+create policy "select_own_splits" on public.transaction_splits
+  for select using (
+    exists (select 1 from public.transactions t where t.id = transaction_id and t.user_id = auth.uid())
+  );
+create policy "insert_own_splits" on public.transaction_splits
+  for insert with check (
+    exists (select 1 from public.transactions t where t.id = transaction_id and t.user_id = auth.uid())
+    and exists (select 1 from public.categories  c where c.id = category_id  and c.user_id = auth.uid())
+  );
+create policy "update_own_splits" on public.transaction_splits
+  for update using (
+    exists (select 1 from public.transactions t where t.id = transaction_id and t.user_id = auth.uid())
+  ) with check (
+    exists (select 1 from public.transactions t where t.id = transaction_id and t.user_id = auth.uid())
+    and exists (select 1 from public.categories  c where c.id = category_id  and c.user_id = auth.uid())
+  );
+create policy "delete_own_splits" on public.transaction_splits
+  for delete using (
+    exists (select 1 from public.transactions t where t.id = transaction_id and t.user_id = auth.uid())
+  );
+
+create policy "select_own_user_settings" on public.user_settings
+  for select using (user_id = auth.uid());
+create policy "upsert_own_user_settings" on public.user_settings
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create policy "select_own_sync_state" on public.sync_state
+  for select using (user_id = auth.uid());
+create policy "upsert_own_sync_state" on public.sync_state
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+-- === 初期カテゴリINSERT用の関数（任意、呼ぶと5分類を挿入） ===
+create or replace function public.seed_default_categories()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.categories (user_id, name, color, is_builtin, sort_order)
+  values
+    (auth.uid(), '乃木坂', '#742581', true, 1),
+    (auth.uid(), '櫻坂', '#f144b6', true, 2),
+    (auth.uid(), '日向坂', '#54d6de', true, 3),
+    (auth.uid(), 'スポーツ', '#E17055', true, 4),
+    (auth.uid(), 'その他', '#B2BEC3', true, 5)
+  on conflict (user_id, name) do nothing;
+end $$;
+
+-- ビューのRLS（必要に応じて）
+-- v_transaction_splits は transactions 経由で制限されるため、明示的ポリシーは不要

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
         "prettier": "^3.6.2",
+        "supabase": "^2.45.5",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
         "vite": "^7.1.7",
@@ -2180,6 +2181,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3273,6 +3287,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3449,6 +3473,23 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bin-links": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-5.0.0.tgz",
+      "integrity": "sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^7.0.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "read-cmd-shim": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3607,6 +3648,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3614,6 +3665,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-7.0.0.tgz",
+      "integrity": "sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/color-convert": {
@@ -3835,6 +3896,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/data-view-buffer": {
@@ -4482,6 +4553,30 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4588,6 +4683,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -4923,6 +5031,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -4944,7 +5066,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
       "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -5704,6 +5825,29 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5734,11 +5878,61 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -6000,6 +6194,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/proc-log": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6136,6 +6340,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-5.0.0.tgz",
+      "integrity": "sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/recharts": {
@@ -6655,6 +6869,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -6852,6 +7079,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supabase": {
+      "version": "2.45.5",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.45.5.tgz",
+      "integrity": "sha512-/toOX6bHYx2TUNA5AtlzrKKfvctbLQ8R6QqvUCAT20KtZOkR14HpBYav3TNDaU5owPeB58cT5Uftvxw36Tb95A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^5.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "node-fetch": "^3.3.2",
+        "tar": "7.4.4"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6875,6 +7122,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
+      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/temp-dir": {
@@ -7299,7 +7573,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -7473,6 +7746,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -7963,6 +8246,20 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
+      "integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
     "prettier": "^3.6.2",
+    "supabase": "^2.45.5",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,0 +1,61 @@
+﻿import { useCallback, useState } from "react";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useAuth } from "../lib/auth";
+
+const navItems = [
+  { to: "/", label: "入力" },
+  { to: "/transactions", label: "履歴" },
+  { to: "/reports", label: "レポート" },
+  { to: "/settings", label: "設定" },
+];
+
+export function AppLayout() {
+  const { user, signOut } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSignOut = useCallback(async () => {
+    setError(null);
+    try {
+      await signOut();
+      navigate("/login", { replace: true });
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "サインアウトに失敗しました");
+    }
+  }, [signOut, navigate]);
+
+  return (
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <div className="app-shell__brand">
+          <span className="app-shell__title">楽勘主義</span>
+          <nav className="app-shell__nav" aria-label="メイン">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `app-shell__nav-link${isActive ? " app-shell__nav-link--active" : ""}`
+                }
+                end={item.to === "/"}
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+        <div className="app-shell__actions">
+          {user?.email ? <span className="app-shell__user">{user.email}</span> : null}
+          <button type="button" className="app-shell__signout" onClick={handleSignOut}>
+            サインアウト
+          </button>
+        </div>
+      </header>
+      {error ? <p role="alert" className="app-shell__error">{error}</p> : null}
+      <main className="app-shell__main">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,29 +1,111 @@
-﻿import { useCallback, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../lib/auth";
+import { useAppBootstrap } from "../lib/hooks/useAppBootstrap";
+import { LoadingScreen } from "./LoadingScreen";
 
 const navItems = [
-  { to: "/", label: "入力" },
+  { to: "/", label: "ホーム" },
   { to: "/transactions", label: "履歴" },
   { to: "/reports", label: "レポート" },
   { to: "/settings", label: "設定" },
 ];
 
+function formatSyncTime(iso?: string) {
+  if (!iso) return "";
+  try {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+      return "";
+    }
+    return new Intl.DateTimeFormat("ja-JP", {
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  } catch (error) {
+    console.warn("Failed to format sync time", error);
+    return "";
+  }
+}
+
 export function AppLayout() {
   const { user, signOut } = useAuth();
-  const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+  const [isOnline, setIsOnline] = useState(typeof navigator !== "undefined" ? navigator.onLine : true);
+  const {
+    isBootstrapping,
+    didBootstrap,
+    bootstrapError,
+    retryBootstrap,
+    isSyncing,
+    syncError,
+    lastSyncedAt,
+    triggerSync,
+  } = useAppBootstrap(user?.id);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const updateOnlineStatus = () => {
+      setIsOnline(typeof navigator !== "undefined" ? navigator.onLine : true);
+    };
+
+    window.addEventListener("online", updateOnlineStatus);
+    window.addEventListener("offline", updateOnlineStatus);
+
+    return () => {
+      window.removeEventListener("online", updateOnlineStatus);
+      window.removeEventListener("offline", updateOnlineStatus);
+    };
+  }, []);
 
   const handleSignOut = useCallback(async () => {
-    setError(null);
+    setSignOutError(null);
     try {
       await signOut();
       navigate("/login", { replace: true });
     } catch (err) {
       console.error(err);
-      setError(err instanceof Error ? err.message : "サインアウトに失敗しました");
+      setSignOutError(err instanceof Error ? err.message : "サインアウトに失敗しました");
     }
   }, [signOut, navigate]);
+
+  const alerts = useMemo(() => {
+    return [signOutError, syncError].filter(Boolean) as string[];
+  }, [signOutError, syncError]);
+
+  const statusLabel = useMemo(() => {
+    if (isSyncing) return "同期中…";
+    const formatted = formatSyncTime(lastSyncedAt);
+    if (formatted) {
+      return `最終同期 ${formatted}`;
+    }
+    return "同期待ち";
+  }, [isSyncing, lastSyncedAt]);
+
+  if (isBootstrapping && !didBootstrap) {
+    return <LoadingScreen label="データを準備しています" />;
+  }
+
+  if (bootstrapError && !didBootstrap) {
+    return (
+      <div className="app-bootstrap-error">
+        <div className="app-bootstrap-error__card" role="alert">
+          <h1 className="app-bootstrap-error__title">データを読み込めませんでした</h1>
+          <p className="app-bootstrap-error__message">{bootstrapError}</p>
+          <button
+            type="button"
+            className="app-bootstrap-error__retry"
+            onClick={retryBootstrap}
+            disabled={isBootstrapping}
+          >
+            再試行
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="app-shell">
@@ -46,16 +128,35 @@ export function AppLayout() {
           </nav>
         </div>
         <div className="app-shell__actions">
+          <div className="app-shell__status" role="status" aria-live="polite">
+            {!isOnline ? (
+              <span className="app-shell__status-badge app-shell__status-badge--offline">オフライン</span>
+            ) : null}
+            <span>{statusLabel}</span>
+          </div>
+          <button
+            type="button"
+            className="app-shell__sync-button"
+            onClick={() => void triggerSync()}
+            disabled={isSyncing || !isOnline}
+          >
+            {isSyncing ? "同期中…" : "再同期"}
+          </button>
           {user?.email ? <span className="app-shell__user">{user.email}</span> : null}
           <button type="button" className="app-shell__signout" onClick={handleSignOut}>
             サインアウト
           </button>
         </div>
       </header>
-      {error ? <p role="alert" className="app-shell__error">{error}</p> : null}
+      {alerts.map((message, index) => (
+        <p key={index} role="alert" className="app-shell__error">
+          {message}
+        </p>
+      ))}
       <main className="app-shell__main">
         <Outlet />
       </main>
     </div>
   );
 }
+

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,17 @@
+﻿import type { CSSProperties } from "react";
+
+const containerStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "100vh",
+  padding: "1.5rem",
+};
+
+export function LoadingScreen({ label = "Loading" }: { label?: string }) {
+  return (
+    <div style={containerStyle} role="status" aria-live="polite">
+      <span>{label}…</span>
+    </div>
+  );
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+﻿import type { ReactNode } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../lib/auth";
+import { LoadingScreen } from "./LoadingScreen";
+
+export function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { session, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  if (!session) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,237 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+﻿:root {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #0f172a;
+  background-color: #f5f7fa;
   text-rendering: optimizeLegibility;
+  font-synthesis: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+* {
+  box-sizing: border-box;
 }
-a:hover {
-  color: #535bf2;
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus {
+  outline: 3px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  background: linear-gradient(180deg, #f5f7fa 0%, #eef2ff 100%);
 }
 
 button {
-  border-radius: 8px;
+  border-radius: 999px;
   border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #2563eb;
+  color: #ffffff;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+button:hover {
+  background-color: #1d4ed8;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.6);
+  outline-offset: 2px;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
+}
+
+.app-shell__brand {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.app-shell__title {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+}
+
+.app-shell__nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.app-shell__nav-link {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  color: rgba(226, 232, 240, 0.75);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-shell__nav-link:hover {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #f8fafc;
+}
+
+.app-shell__nav-link--active {
+  background-color: #2563eb;
+  color: #f8fafc;
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.3);
+}
+
+.app-shell__actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-shell__user {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.app-shell__signout {
+  background-color: rgba(248, 250, 252, 0.1);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.4rem 1rem;
+}
+
+.app-shell__signout:hover {
+  background-color: rgba(248, 250, 252, 0.25);
+  transform: translateY(-1px);
+}
+
+.app-shell__error {
+  margin: 0;
+  padding: 0.75rem 1.5rem;
+  background-color: #fee2e2;
+  color: #991b1b;
+  border-bottom: 1px solid #fecaca;
+}
+
+.app-shell__main {
+  flex: 1;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .app-shell__header {
+    padding: 0.75rem 1rem;
   }
-  a:hover {
-    color: #747bff;
+
+  .app-shell__main {
+    padding: 1rem;
   }
-  button {
-    background-color: #f9f9f9;
-  }
+}
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+}
+
+.login-card {
+  width: min(420px, 100%);
+  background-color: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #1e293b;
+}
+
+.login-card__hint {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-form__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.login-form__input {
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  padding: 0.6rem 0.9rem;
+  font-size: 1rem;
+  background-color: #f8fafc;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form__input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  outline: none;
+}
+
+.login-form button[disabled] {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.login-card__success {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.login-card__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background-color: #fee2e2;
+  color: #991b1b;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -325,3 +325,270 @@ button:focus-visible {
   color: #991b1b;
 }
 
+.home {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.home__layout {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 960px) {
+  .home__layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    align-items: flex-start;
+  }
+}
+
+.home__form,
+.home__recent {
+  background-color: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+@media (max-width: 640px) {
+  .home__form,
+  .home__recent {
+    padding: 1.25rem;
+  }
+}
+
+.home__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.home__title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+.home__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.home__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.home__field--categories {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.home__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.home__input,
+.home__input[type="date"],
+.home__input[type="number"],
+.home__input[type="text"],
+.home__input select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: rgba(241, 245, 249, 0.6);
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home__input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.home__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.home__two-column {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .home__two-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.home__categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.home__category {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background-color: rgba(248, 250, 252, 0.8);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.home__category input {
+  accent-color: #2563eb;
+}
+
+.home__category--selected {
+  border-color: #2563eb;
+  background-color: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.home__actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.home__submit {
+  padding: 0.65rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.home__status {
+  margin: 0;
+  padding: 0.6rem 0.9rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.home__status--success {
+  background-color: #dcfce7;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+
+.home__status--error {
+  background-color: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.home__recent-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.home__recent-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.home__recent-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.home__recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home__transaction {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.home__transaction:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.home__transaction-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.home__transaction-date {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.home__transaction-amount {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.home__transaction-memo {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.home__transaction-categories {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.home__transaction-categories li {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background-color: rgba(226, 232, 240, 0.6);
+}
+
+.home__pending {
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background-color: rgba(250, 204, 21, 0.2);
+  color: #92400e;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.home__empty {
+  margin: 0;
+  padding: 1rem 0;
+  color: #64748b;
+  text-align: center;
+  font-size: 0.95rem;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -113,9 +113,98 @@ button:focus-visible {
   gap: 1rem;
 }
 
+
+.app-shell__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
 .app-shell__user {
   font-size: 0.9rem;
   color: rgba(226, 232, 240, 0.9);
+}
+
+.app-shell__status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.75rem;
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.app-shell__status-badge--offline {
+  background-color: rgba(248, 113, 113, 0.35);
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #fee2e2;
+}
+
+.app-shell__sync-button {
+  background-color: rgba(248, 250, 252, 0.12);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.35rem 0.9rem;
+}
+
+.app-shell__sync-button:hover {
+  background-color: rgba(248, 250, 252, 0.25);
+  transform: translateY(-1px);
+}
+
+.app-shell__sync-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.app-bootstrap-error {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: linear-gradient(180deg, #f5f7fa 0%, #eef2ff 100%);
+}
+
+.app-bootstrap-error__card {
+  width: min(420px, 100%);
+  background-color: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+.app-bootstrap-error__title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1e293b;
+}
+
+.app-bootstrap-error__message {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.app-bootstrap-error__retry {
+  align-self: center;
+  padding: 0.5rem 1.5rem;
+}
+
+.app-bootstrap-error__retry:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .app-shell__signout {
@@ -235,3 +324,4 @@ button:focus-visible {
   background-color: #fee2e2;
   color: #991b1b;
 }
+

--- a/src/index.css
+++ b/src/index.css
@@ -592,3 +592,232 @@ button:focus-visible {
   text-align: center;
   font-size: 0.95rem;
 }
+.transactions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.transactions__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.transactions__header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+.transactions__header p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.transactions__summary {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.transactions__summary-card {
+  background-color: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 15px 36px rgba(15, 23, 42, 0.12);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.transactions__summary-label {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.transactions__summary-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.transactions__filters,
+.transactions__list {
+  background-color: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .transactions__filters,
+  .transactions__list {
+    padding: 1.25rem;
+  }
+}
+
+.transactions__filters-row {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .transactions__filters-row {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    align-items: end;
+  }
+}
+
+.transactions__filters-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.transactions__filters-label {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.transactions__filters-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.transactions__filters-apply {
+  padding: 0.55rem 1.25rem;
+}
+
+.transactions__filters-reset {
+  padding: 0.55rem 1rem;
+  background-color: rgba(148, 163, 184, 0.12);
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.transactions__filters-reset:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.transactions__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.transactions__loading {
+  margin: 0;
+  padding: 0.5rem 0;
+  color: #475569;
+}
+
+.transactions__empty {
+  margin: 0;
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  background-color: rgba(241, 245, 249, 0.7);
+  color: #475569;
+  text-align: center;
+}
+
+.transactions__table-container {
+  overflow-x: auto;
+}
+
+.transactions__table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.transactions__table th,
+.transactions__table td {
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.transactions__table th {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.transactions__cell--amount {
+  text-align: right;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.transactions__cell--memo {
+  max-width: 320px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.transactions__memo-placeholder {
+  color: #94a3b8;
+}
+
+.transactions__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.transactions__badge--pending {
+  background-color: rgba(250, 204, 21, 0.2);
+  color: #92400e;
+}
+
+.transactions__badge--synced {
+  background-color: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.transactions__categories {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.transactions__note {
+  margin: 0;
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (max-width: 880px) {
+  .transactions__table {
+    min-width: 600px;
+  }
+}
+
+@media (max-width: 640px) {
+  .transactions__table th,
+  .transactions__table td {
+    padding: 0.65rem 0.75rem;
+    font-size: 0.9rem;
+  }
+}

--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -1,0 +1,21 @@
+﻿import { supabase } from "../supabase";
+
+export type Account = {
+  id: string;
+  user_id?: string | null;
+  name: string;
+  type: "credit" | "debit" | "cash" | "other";
+  is_active: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function listAccounts(): Promise<Account[]> {
+  const { data, error } = await supabase
+    .from("accounts")
+    .select("id, user_id, name, type, is_active, sort_order, created_at, updated_at")
+    .order("sort_order", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}

--- a/src/lib/api/categories.ts
+++ b/src/lib/api/categories.ts
@@ -1,0 +1,28 @@
+﻿// src/lib/api/categories.ts
+import { supabase } from "../supabase";
+
+export type Category = {
+  id: string;
+  user_id?: string | null;
+  name: string;
+  color?: string | null;
+  is_builtin: boolean;
+  is_active: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function seedDefaultCategories() {
+  const { error } = await supabase.rpc("seed_default_categories");
+  if (error) throw error;
+}
+
+export async function listCategories(): Promise<Category[]> {
+  const { data, error } = await supabase
+    .from("categories")
+    .select("*")
+    .order("sort_order", { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./categories";
+export * from "./transactions";

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,2 +1,3 @@
-export * from "./categories";
+﻿export * from "./categories";
+export * from "./accounts";
 export * from "./transactions";

--- a/src/lib/api/transactions.ts
+++ b/src/lib/api/transactions.ts
@@ -1,0 +1,115 @@
+// src/lib/api/transactions.ts
+import { v4 as uuidv4 } from "uuid";
+import { supabase } from "../supabase";
+
+export type Transaction = {
+  id: string;
+  user_id?: string | null;
+  account_id: string;
+  amount: number;
+  memo?: string | null;
+  occurred_at: string; // YYYY-MM-DD
+  created_at?: string;
+  updated_at: string;
+  is_deleted: boolean;
+};
+
+export type TransactionSplit = {
+  id: string;
+  transaction_id: string;
+  category_id: string;
+  ratio: number; // 0~1
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type TransactionWithSplits = Transaction & {
+  transaction_splits: TransactionSplit[];
+};
+
+export type CreateTransactionInput = {
+  id?: string;
+  accountId: string;
+  amount: number;
+  occurredAt: string; // YYYY-MM-DD
+  memo?: string;
+  categoryIds?: string[];
+  splits?: Array<{ id?: string; categoryId: string; ratio: number }>;
+};
+
+export async function createTransaction(input: CreateTransactionInput) {
+  const { accountId, amount, occurredAt, memo } = input;
+  const transactionId = input.id ?? uuidv4();
+
+  const insertPayload: Record<string, unknown> = {
+    id: transactionId,
+    account_id: accountId,
+    amount,
+    occurred_at: occurredAt,
+    memo,
+  };
+
+  const { data: tx, error: txErr } = await supabase
+    .from("transactions")
+    .insert([insertPayload])
+    .select("id, user_id, account_id, amount, memo, occurred_at, created_at, updated_at, is_deleted")
+    .single();
+
+  if (txErr) throw txErr;
+
+  const splitSources: Array<{ id?: string; categoryId: string; ratio: number }> =
+    input.splits?.length
+      ? input.splits
+      : (input.categoryIds ?? []).map((categoryId, _index, arr) => ({
+          categoryId,
+          ratio: arr.length > 0 ? 1 / arr.length : 1,
+        }));
+
+  let splits: TransactionSplit[] = [];
+
+  if (splitSources.length > 0) {
+    const rows = splitSources.map((split) => ({
+      id: split.id ?? uuidv4(),
+      transaction_id: tx.id,
+      category_id: split.categoryId,
+      ratio: split.ratio,
+    }));
+
+    const { data: insertedSplits, error: spErr } = await supabase
+      .from("transaction_splits")
+      .insert(rows)
+      .select("id, transaction_id, category_id, ratio, created_at, updated_at");
+
+    if (spErr) throw spErr;
+    splits = insertedSplits ?? [];
+  }
+
+  return { ...tx, transaction_splits: splits } as TransactionWithSplits;
+}
+
+export async function listTransactions(limit = 200) {
+  const { data, error } = await supabase
+    .from("transactions")
+    .select(
+      `
+      id, user_id, account_id, amount, memo, occurred_at, created_at, updated_at, is_deleted,
+      transaction_splits ( id, transaction_id, category_id, ratio, created_at, updated_at )
+    `
+    )
+    .eq("is_deleted", false)
+    .order("occurred_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []) as TransactionWithSplits[];
+}
+
+export async function listSplitsWithAmount(txId: string) {
+  const { data, error } = await supabase
+    .from("v_transaction_splits")
+    .select("transaction_id, category_id, ratio, amount_calc")
+    .eq("transaction_id", txId);
+  if (error) throw error;
+  return data as Array<{ transaction_id: string; category_id: string; ratio: number; amount_calc: number }>;
+}
+
+

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,0 +1,69 @@
+﻿import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { supabase } from "./supabase";
+
+export type AuthContextValue = {
+  user: User | null;
+  session: Session | null;
+  isLoading: boolean;
+  signOut: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadInitialSession() {
+      try {
+        const {
+          data: { session: initialSession },
+          error,
+        } = await supabase.auth.getSession();
+        if (error) throw error;
+        if (active) setSession(initialSession ?? null);
+      } catch (error) {
+        console.error("Failed to load auth session", error);
+        if (active) setSession(null);
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    }
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession ?? null);
+      setIsLoading(false);
+    });
+
+    loadInitialSession();
+
+    return () => {
+      active = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user: session?.user ?? null,
+    session,
+    isLoading,
+    async signOut() {
+      const { error } = await supabase.auth.signOut();
+      if (error) throw error;
+    },
+  }), [session, isLoading]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used inside an AuthProvider");
+  return ctx;
+}

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,5 +1,6 @@
 ﻿import Dexie, { type Table } from "dexie";
 import type {
+  AccountRecord,
   CategoryRecord,
   TransactionRecord,
   TransactionSplitRecord,
@@ -7,6 +8,7 @@ import type {
 } from "./schema";
 
 class RakanshugiDatabase extends Dexie {
+  accounts!: Table<AccountRecord, string>;
   categories!: Table<CategoryRecord, string>;
   transactions!: Table<TransactionRecord, string>;
   transactionSplits!: Table<TransactionSplitRecord, string>;
@@ -16,6 +18,14 @@ class RakanshugiDatabase extends Dexie {
     super("rakanshugi-db");
 
     this.version(1).stores({
+      categories: "&id, userId, sortOrder, isActive, isBuiltin, updatedAt",
+      transactions: "&id, userId, occurredAt, updatedAt, isDeleted, pendingSync",
+      transactionSplits: "&id, transactionId, categoryId",
+      syncQueue: "&id, userId, entity, operation, createdAt",
+    });
+
+    this.version(2).stores({
+      accounts: "&id, userId, isActive, sortOrder, updatedAt",
       categories: "&id, userId, sortOrder, isActive, isBuiltin, updatedAt",
       transactions: "&id, userId, occurredAt, updatedAt, isDeleted, pendingSync",
       transactionSplits: "&id, transactionId, categoryId",

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,0 +1,27 @@
+﻿import Dexie, { type Table } from "dexie";
+import type {
+  CategoryRecord,
+  TransactionRecord,
+  TransactionSplitRecord,
+  SyncOperationRecord,
+} from "./schema";
+
+class RakanshugiDatabase extends Dexie {
+  categories!: Table<CategoryRecord, string>;
+  transactions!: Table<TransactionRecord, string>;
+  transactionSplits!: Table<TransactionSplitRecord, string>;
+  syncQueue!: Table<SyncOperationRecord, string>;
+
+  constructor() {
+    super("rakanshugi-db");
+
+    this.version(1).stores({
+      categories: "&id, userId, sortOrder, isActive, isBuiltin, updatedAt",
+      transactions: "&id, userId, occurredAt, updatedAt, isDeleted, pendingSync",
+      transactionSplits: "&id, transactionId, categoryId",
+      syncQueue: "&id, userId, entity, operation, createdAt",
+    });
+  }
+}
+
+export const db = new RakanshugiDatabase();

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,0 +1,2 @@
+﻿export { db } from "./client";
+export * from "./schema";

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,0 +1,48 @@
+﻿export type CategoryRecord = {
+  id: string;
+  userId: string;
+  name: string;
+  color: string | null;
+  isBuiltin: boolean;
+  isActive: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TransactionRecord = {
+  id: string;
+  userId: string;
+  accountId: string;
+  amount: number;
+  memo: string | null;
+  occurredAt: string;
+  createdAt: string;
+  updatedAt: string;
+  isDeleted: boolean;
+  pendingSync: boolean;
+};
+
+export type TransactionSplitRecord = {
+  id: string;
+  transactionId: string;
+  categoryId: string;
+  ratio: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SyncOperationRecord = {
+  id: string;
+  userId: string;
+  entity: "transactions";
+  operation: "insert" | "update" | "delete";
+  payload: unknown;
+  createdAt: string;
+  retryCount: number;
+  lastTriedAt?: string;
+};
+
+export type TransactionWithSplits = TransactionRecord & {
+  splits: TransactionSplitRecord[];
+};

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,15 @@
-﻿export type CategoryRecord = {
+﻿export type AccountRecord = {
+  id: string;
+  userId: string;
+  name: string;
+  type: "credit" | "debit" | "cash" | "other";
+  isActive: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CategoryRecord = {
   id: string;
   userId: string;
   name: string;

--- a/src/lib/hooks/useAppBootstrap.ts
+++ b/src/lib/hooks/useAppBootstrap.ts
@@ -1,0 +1,173 @@
+﻿import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  bootstrapUserData,
+  refreshUserDataFromRemote,
+  syncOutboundChanges,
+} from "../store";
+
+type BootstrapPhase = "idle" | "bootstrapping" | "ready" | "error";
+
+type BootstrapState = {
+  phase: BootstrapPhase;
+  message?: string;
+};
+
+type SyncState = {
+  isSyncing: boolean;
+  lastSyncedAt?: string;
+  error?: string;
+};
+
+const BOOTSTRAP_ERROR_MESSAGE = "データの初期化に失敗しました";
+const SYNC_ERROR_MESSAGE = "同期に失敗しました";
+const SYNC_INTERVAL_MS = 60_000;
+
+export function useAppBootstrap(userId?: string) {
+  const [bootstrapState, setBootstrapState] = useState<BootstrapState>({ phase: "idle" });
+  const [bootstrapAttempt, setBootstrapAttempt] = useState(0);
+  const [syncState, setSyncState] = useState<SyncState>({ isSyncing: false });
+  const isMountedRef = useRef(true);
+  const syncInFlightRef = useRef(false);
+
+  useEffect(() => () => {
+    isMountedRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    setSyncState({ isSyncing: false, lastSyncedAt: undefined, error: undefined });
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) {
+      setBootstrapState({ phase: "idle" });
+      return;
+    }
+
+    const targetUserId = userId as string;
+    let cancelled = false;
+
+    async function runBootstrap() {
+      setBootstrapState({ phase: "bootstrapping" });
+      try {
+        await bootstrapUserData(targetUserId);
+        if (!cancelled) {
+          setBootstrapState({ phase: "ready" });
+        }
+      } catch (error) {
+        console.error("Failed to bootstrap user data", error);
+        if (!cancelled) {
+          setBootstrapState({
+            phase: "error",
+            message: error instanceof Error ? error.message : BOOTSTRAP_ERROR_MESSAGE,
+          });
+        }
+      }
+    }
+
+    runBootstrap();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, bootstrapAttempt]);
+
+  const triggerSync = useCallback(async () => {
+    if (!userId || !isMountedRef.current) return;
+    if (syncInFlightRef.current) return;
+    if (typeof navigator !== "undefined" && !navigator.onLine) return;
+
+    const targetUserId = userId as string;
+
+    syncInFlightRef.current = true;
+    setSyncState((prev) => ({ ...prev, isSyncing: true, error: undefined }));
+
+    let refreshed = false;
+    let errorMessage: string | undefined;
+
+    try {
+      try {
+        await syncOutboundChanges(targetUserId);
+      } catch (error) {
+        console.warn("Failed to push pending changes", error);
+        if (!errorMessage) {
+          errorMessage = error instanceof Error ? error.message : SYNC_ERROR_MESSAGE;
+        }
+      }
+
+      try {
+        await refreshUserDataFromRemote(targetUserId);
+        refreshed = true;
+      } catch (error) {
+        console.warn("Failed to refresh user data", error);
+        errorMessage = error instanceof Error ? error.message : SYNC_ERROR_MESSAGE;
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setSyncState((prev) => ({
+          isSyncing: false,
+          lastSyncedAt: refreshed ? new Date().toISOString() : prev.lastSyncedAt,
+          error: errorMessage,
+        }));
+      }
+      syncInFlightRef.current = false;
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId || bootstrapState.phase !== "ready") return;
+
+    const attemptInitialSync = () => {
+      if (typeof navigator !== "undefined" && !navigator.onLine) return;
+      void triggerSync();
+    };
+
+    attemptInitialSync();
+
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const handleOnline = () => {
+      attemptInitialSync();
+    };
+
+    window.addEventListener("online", handleOnline);
+    const intervalId = window.setInterval(() => {
+      attemptInitialSync();
+    }, SYNC_INTERVAL_MS);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.clearInterval(intervalId);
+    };
+  }, [userId, bootstrapState.phase, triggerSync]);
+
+  const retryBootstrap = useCallback(() => {
+    setBootstrapAttempt((prev) => prev + 1);
+  }, []);
+
+  const didBootstrap = bootstrapState.phase === "ready";
+  const isBootstrapping = bootstrapState.phase === "bootstrapping";
+  const bootstrapError = bootstrapState.phase === "error" ? bootstrapState.message : undefined;
+
+  const hasSyncedOnce = useMemo(() => Boolean(syncState.lastSyncedAt), [syncState.lastSyncedAt]);
+
+  return {
+    isBootstrapping,
+    didBootstrap,
+    bootstrapError,
+    retryBootstrap,
+    isSyncing: syncState.isSyncing,
+    syncError: syncState.error,
+    lastSyncedAt: syncState.lastSyncedAt,
+    hasSyncedOnce,
+    triggerSync,
+  } as const;
+}
+
+
+
+
+
+
+

--- a/src/lib/store/accounts.ts
+++ b/src/lib/store/accounts.ts
@@ -43,9 +43,6 @@ export const useAccountStore = create<AccountState>((set) => ({
   async refreshFromRemote(userId) {
     try {
       const remote = await listAccounts();
-      if (!remote || remote.length === 0) {
-        return;
-      }
 
       const mapped = remote
         .map((record) => mapAccount(record, userId))
@@ -53,7 +50,9 @@ export const useAccountStore = create<AccountState>((set) => ({
 
       await db.transaction("rw", db.accounts, async () => {
         await db.accounts.where("userId").equals(userId).delete();
-        await db.accounts.bulkPut(mapped);
+        if (mapped.length > 0) {
+          await db.accounts.bulkPut(mapped);
+        }
       });
 
       set({ items: mapped, error: undefined });

--- a/src/lib/store/accounts.ts
+++ b/src/lib/store/accounts.ts
@@ -1,0 +1,65 @@
+﻿import { create } from "zustand";
+import { db, type AccountRecord } from "../db";
+import { listAccounts, type Account } from "../api";
+
+export type AccountState = {
+  items: AccountRecord[];
+  isLoading: boolean;
+  error?: string;
+  initialize(userId: string): Promise<void>;
+  refreshFromRemote(userId: string): Promise<void>;
+};
+
+function mapAccount(record: Account, userId: string): AccountRecord {
+  return {
+    id: record.id,
+    userId: record.user_id ?? userId,
+    name: record.name,
+    type: record.type,
+    isActive: record.is_active,
+    sortOrder: record.sort_order,
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  };
+}
+
+export const useAccountStore = create<AccountState>((set) => ({
+  items: [],
+  isLoading: false,
+  error: undefined,
+  async initialize(userId) {
+    set({ isLoading: true, error: undefined });
+    try {
+      const cached = await db.accounts.where("userId").equals(userId).sortBy("sortOrder");
+      set({ items: cached, isLoading: false });
+    } catch (error) {
+      console.error("Failed to read accounts from IndexedDB", error);
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "支払アカウントの読み込みに失敗しました",
+      });
+    }
+  },
+  async refreshFromRemote(userId) {
+    try {
+      const remote = await listAccounts();
+      if (!remote || remote.length === 0) {
+        return;
+      }
+
+      const mapped = remote
+        .map((record) => mapAccount(record, userId))
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+
+      await db.transaction("rw", db.accounts, async () => {
+        await db.accounts.where("userId").equals(userId).delete();
+        await db.accounts.bulkPut(mapped);
+      });
+
+      set({ items: mapped, error: undefined });
+    } catch (error) {
+      console.error("Failed to fetch accounts from Supabase", error);
+      set({ error: error instanceof Error ? error.message : "支払アカウントの取得に失敗しました" });
+    }
+  },
+}));

--- a/src/lib/store/bootstrap.ts
+++ b/src/lib/store/bootstrap.ts
@@ -1,8 +1,10 @@
-﻿import { useCategoryStore } from "./categories";
+﻿import { useAccountStore } from "./accounts";
+import { useCategoryStore } from "./categories";
 import { useTransactionStore } from "./transactions";
 
 export async function bootstrapUserData(userId: string) {
   await Promise.all([
+    useAccountStore.getState().initialize(userId),
     useCategoryStore.getState().initialize(userId),
     useTransactionStore.getState().initialize(userId),
   ]);
@@ -10,6 +12,7 @@ export async function bootstrapUserData(userId: string) {
 
 export async function refreshUserDataFromRemote(userId: string) {
   await Promise.allSettled([
+    useAccountStore.getState().refreshFromRemote(userId),
     useCategoryStore.getState().refreshFromRemote(userId),
     useTransactionStore.getState().refreshFromRemote(userId),
   ]);

--- a/src/lib/store/bootstrap.ts
+++ b/src/lib/store/bootstrap.ts
@@ -1,0 +1,20 @@
+﻿import { useCategoryStore } from "./categories";
+import { useTransactionStore } from "./transactions";
+
+export async function bootstrapUserData(userId: string) {
+  await Promise.all([
+    useCategoryStore.getState().initialize(userId),
+    useTransactionStore.getState().initialize(userId),
+  ]);
+}
+
+export async function refreshUserDataFromRemote(userId: string) {
+  await Promise.allSettled([
+    useCategoryStore.getState().refreshFromRemote(userId),
+    useTransactionStore.getState().refreshFromRemote(userId),
+  ]);
+}
+
+export async function syncOutboundChanges(userId: string) {
+  await useTransactionStore.getState().syncPending(userId);
+}

--- a/src/lib/store/categories.ts
+++ b/src/lib/store/categories.ts
@@ -1,0 +1,68 @@
+﻿import { create } from "zustand";
+import { db, type CategoryRecord } from "../db";
+import { listCategories, seedDefaultCategories, type Category } from "../api";
+
+export type CategoryState = {
+  items: CategoryRecord[];
+  isLoading: boolean;
+  error?: string;
+  initialize(userId: string): Promise<void>;
+  refreshFromRemote(userId: string): Promise<void>;
+};
+
+function mapCategory(record: Category, userId: string): CategoryRecord {
+  return {
+    id: record.id,
+    userId: record.user_id ?? userId,
+    name: record.name,
+    color: record.color ?? null,
+    isBuiltin: record.is_builtin,
+    isActive: record.is_active,
+    sortOrder: record.sort_order,
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  };
+}
+
+export const useCategoryStore = create<CategoryState>((set) => ({
+  items: [],
+  isLoading: false,
+  error: undefined,
+  async initialize(userId) {
+    set({ isLoading: true, error: undefined });
+    try {
+      const cached = await db.categories.where("userId").equals(userId).sortBy("sortOrder");
+      set({ items: cached, isLoading: false });
+    } catch (error) {
+      console.error("Failed to read categories from IndexedDB", error);
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "カテゴリの読み込みに失敗しました",
+      });
+    }
+  },
+  async refreshFromRemote(userId) {
+    try {
+      let remote = await listCategories();
+      if (!remote || remote.length === 0) {
+        await seedDefaultCategories();
+        remote = await listCategories();
+        if (!remote || remote.length === 0) {
+          return;
+        }
+      }
+
+      const mapped = remote.map((item) => mapCategory(item, userId)).sort((a, b) => a.sortOrder - b.sortOrder);
+
+      await db.transaction("rw", db.categories, async () => {
+        await db.categories.where("userId").equals(userId).delete();
+        await db.categories.bulkPut(mapped);
+      });
+
+      set({ items: mapped, error: undefined });
+    } catch (error) {
+      console.error("Failed to fetch categories from Supabase", error);
+      set({ error: error instanceof Error ? error.message : "カテゴリの取得に失敗しました" });
+    }
+  },
+}));

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -1,0 +1,3 @@
+﻿export { useCategoryStore } from "./categories";
+export { useTransactionStore } from "./transactions";
+export { bootstrapUserData, refreshUserDataFromRemote, syncOutboundChanges } from "./bootstrap";

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -1,3 +1,4 @@
-﻿export { useCategoryStore } from "./categories";
+﻿export { useAccountStore } from "./accounts";
+export { useCategoryStore } from "./categories";
 export { useTransactionStore } from "./transactions";
 export { bootstrapUserData, refreshUserDataFromRemote, syncOutboundChanges } from "./bootstrap";

--- a/src/lib/store/transactions.ts
+++ b/src/lib/store/transactions.ts
@@ -1,0 +1,235 @@
+import { create } from "zustand";
+import { v4 as uuidv4 } from "uuid";
+import {
+  db,
+  type TransactionWithSplits as StoredTransaction,
+  type TransactionRecord,
+  type TransactionSplitRecord,
+  type SyncOperationRecord,
+} from "../db";
+import {
+  createTransaction as createRemoteTransaction,
+  listTransactions as listRemoteTransactions,
+  type TransactionWithSplits as RemoteTransaction,
+} from "../api";
+
+type AddTransactionInput = {
+  userId: string;
+  accountId: string;
+  amount: number;
+  occurredAt: string;
+  memo?: string;
+  categoryIds?: string[];
+  splits?: Array<{ categoryId: string; ratio: number; id?: string }>; 
+};
+
+type TransactionsState = {
+  items: StoredTransaction[];
+  isLoading: boolean;
+  error?: string;
+  initialize(userId: string): Promise<void>;
+  addTransaction(input: AddTransactionInput): Promise<void>;
+  syncPending(userId: string): Promise<void>;
+  refreshFromRemote(userId: string): Promise<void>;
+};
+
+type TransactionOutboxPayload = {
+  transaction: TransactionRecord;
+  splits: TransactionSplitRecord[];
+};
+
+function mapRemoteTransaction(record: RemoteTransaction, userId: string): StoredTransaction {
+  const splits = (record.transaction_splits ?? []).map((split) => ({
+    id: split.id,
+    transactionId: split.transaction_id,
+    categoryId: split.category_id,
+    ratio: split.ratio,
+    createdAt: split.created_at ?? record.created_at ?? record.updated_at,
+    updatedAt: split.updated_at ?? record.updated_at,
+  } satisfies TransactionSplitRecord));
+
+  return {
+    id: record.id,
+    userId: record.user_id ?? userId,
+    accountId: record.account_id,
+    amount: record.amount,
+    memo: record.memo ?? null,
+    occurredAt: record.occurred_at,
+    createdAt: record.created_at ?? record.updated_at,
+    updatedAt: record.updated_at,
+    isDeleted: record.is_deleted,
+    pendingSync: false,
+    splits,
+  } satisfies StoredTransaction;
+}
+
+function toTransactionRecord(tx: StoredTransaction): TransactionRecord {
+  const { splits: _splits, ...transaction } = tx;
+  return transaction;
+}
+
+async function loadTransactionsFromDexie(userId: string): Promise<StoredTransaction[]> {
+  const rows = await db.transactions.where("userId").equals(userId).filter((row) => !row.isDeleted).toArray();
+  const transactions: StoredTransaction[] = [];
+  for (const row of rows) {
+    const splits = await db.transactionSplits.where("transactionId").equals(row.id).toArray();
+    transactions.push({ ...row, splits });
+  }
+  return transactions.sort((a, b) => {
+    if (a.occurredAt === b.occurredAt) {
+      return b.updatedAt.localeCompare(a.updatedAt);
+    }
+    return b.occurredAt.localeCompare(a.occurredAt);
+  });
+}
+
+function buildOutboxRecord(payload: TransactionOutboxPayload, userId: string): SyncOperationRecord {
+  return {
+    id: uuidv4(),
+    userId,
+    entity: "transactions",
+    operation: "insert",
+    payload,
+    createdAt: new Date().toISOString(),
+    retryCount: 0,
+  } satisfies SyncOperationRecord;
+}
+
+export const useTransactionStore = create<TransactionsState>((set) => ({
+  items: [],
+  isLoading: false,
+  error: undefined,
+  async initialize(userId) {
+    set({ isLoading: true, error: undefined });
+    try {
+      const transactions = await loadTransactionsFromDexie(userId);
+      set({ items: transactions, isLoading: false });
+    } catch (error) {
+      console.error("Failed to load transactions from IndexedDB", error);
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : "Žæˆø‚Ì“Ç‚Ýž‚Ý‚ÉŽ¸”s‚µ‚Ü‚µ‚½",
+      });
+    }
+  },
+  async addTransaction(input) {
+    const { userId, accountId, amount, occurredAt, memo } = input;
+    const transactionId = uuidv4();
+    const now = new Date().toISOString();
+
+    const baseCategories = input.categoryIds ?? [];
+    const ratio = baseCategories.length > 0 ? 1 / baseCategories.length : 1;
+    const splitSources: Array<{ categoryId: string; ratio: number; id?: string }> =
+      input.splits?.length ? input.splits : baseCategories.map((categoryId) => ({ categoryId, ratio }));
+
+    const splitRecords: TransactionSplitRecord[] = splitSources.map((split) => ({
+      id: uuidv4(),
+      transactionId,
+      categoryId: split.categoryId,
+      ratio: split.ratio,
+      createdAt: now,
+      updatedAt: now,
+    }));
+
+    const transactionRecord: TransactionRecord = {
+      id: transactionId,
+      userId,
+      accountId,
+      amount,
+      memo: memo ?? null,
+      occurredAt,
+      createdAt: now,
+      updatedAt: now,
+      isDeleted: false,
+      pendingSync: true,
+    };
+
+    const outboxRecord = buildOutboxRecord(
+      {
+        transaction: transactionRecord,
+        splits: splitRecords,
+      },
+      userId
+    );
+
+    await db.transaction("rw", db.transactions, db.transactionSplits, db.syncQueue, async () => {
+      await db.transactions.put(transactionRecord);
+      if (splitRecords.length > 0) {
+        await db.transactionSplits.bulkPut(splitRecords);
+      }
+      await db.syncQueue.put(outboxRecord);
+    });
+
+    set((state) => ({
+      items: [{ ...transactionRecord, splits: splitRecords }, ...state.items],
+    }));
+  },
+  async syncPending(userId) {
+    const operations = await db.syncQueue.where("userId").equals(userId).sortBy("createdAt");
+    if (operations.length === 0) return;
+
+    for (const op of operations) {
+      if (op.entity !== "transactions" || op.operation !== "insert") continue;
+
+      const payload = op.payload as TransactionOutboxPayload;
+      try {
+        await createRemoteTransaction({
+          id: payload.transaction.id,
+          accountId: payload.transaction.accountId,
+          amount: payload.transaction.amount,
+          occurredAt: payload.transaction.occurredAt,
+          memo: payload.transaction.memo ?? undefined,
+          splits: payload.splits.map((split) => ({
+            id: split.id,
+            categoryId: split.categoryId,
+            ratio: split.ratio,
+          })),
+        });
+
+        await db.transaction("rw", db.transactions, db.syncQueue, async () => {
+          await db.syncQueue.delete(op.id);
+          await db.transactions.update(payload.transaction.id, {
+            pendingSync: false,
+            updatedAt: new Date().toISOString(),
+          });
+        });
+      } catch (error) {
+        console.warn("Failed to sync transaction", error);
+        await db.syncQueue.update(op.id, {
+          retryCount: op.retryCount + 1,
+          lastTriedAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    const transactions = await loadTransactionsFromDexie(userId);
+    set({ items: transactions });
+  },
+  async refreshFromRemote(userId) {
+    try {
+      const remote = await listRemoteTransactions();
+      const mapped = remote
+        .filter((tx) => !tx.is_deleted)
+        .map((tx) => mapRemoteTransaction(tx, userId));
+
+      await db.transaction("rw", db.transactions, db.transactionSplits, async () => {
+        for (const tx of mapped) {
+          await db.transactions.put(toTransactionRecord(tx));
+          await db.transactionSplits.where("transactionId").equals(tx.id).delete();
+        }
+        const splitRecords = mapped.flatMap((tx) => tx.splits);
+        if (splitRecords.length > 0) {
+          await db.transactionSplits.bulkPut(splitRecords);
+        }
+      });
+
+      const transactions = await loadTransactionsFromDexie(userId);
+      set({ items: transactions, error: undefined });
+    } catch (error) {
+      console.error("Failed to fetch transactions from Supabase", error);
+      set({ error: error instanceof Error ? error.message : "Žæˆø‚ÌŽæ“¾‚ÉŽ¸”s‚µ‚Ü‚µ‚½" });
+    }
+  },
+}));
+
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,52 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+﻿// src/main.tsx
+import React, { Suspense } from "react";
+import ReactDOM from "react-dom/client";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import "./index.css";
+import { AuthProvider } from "./lib/auth";
+import { AppLayout } from "./components/AppLayout";
+import { ProtectedRoute } from "./components/ProtectedRoute";
+import { LoadingScreen } from "./components/LoadingScreen";
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const Home = React.lazy(() => import("./pages/Home"));
+const Transactions = React.lazy(() => import("./pages/Transactions"));
+const Reports = React.lazy(() => import("./pages/Reports"));
+const Settings = React.lazy(() => import("./pages/Settings"));
+const Login = React.lazy(() => import("./pages/Login"));
+
+const router = createBrowserRouter([
+  { path: "/login", element: <Login /> },
+  {
+    path: "/",
+    element: (
+      <ProtectedRoute>
+        <AppLayout />
+      </ProtectedRoute>
+    ),
+    children: [
+      { index: true, element: <Home /> },
+      { path: "transactions", element: <Transactions /> },
+      { path: "reports", element: <Reports /> },
+      { path: "settings", element: <Settings /> },
+      {
+        path: "*",
+        element: (
+          <div style={{ padding: "1.5rem" }}>
+            <h1 style={{ marginBottom: "0.5rem" }}>404 Not Found</h1>
+            <p>ページが見つかりませんでした。</p>
+          </div>
+        ),
+      },
+    ],
+  },
+]);
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <Suspense fallback={<LoadingScreen />}>
+        <RouterProvider router={router} />
+      </Suspense>
+    </AuthProvider>
+  </React.StrictMode>
+);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,8 @@
+﻿export default function Home() {
+  return (
+    <div>
+      <h1>ホーム</h1>
+      <p>ここに即入力フォームを配置します。</p>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,323 @@
-﻿export default function Home() {
+﻿import { useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent } from "react";
+import { format } from "date-fns";
+import { useAuth } from "../lib/auth";
+import {
+  useAccountStore,
+  useCategoryStore,
+  useTransactionStore,
+} from "../lib/store";
+
+type FormStatus =
+  | { type: "idle" }
+  | { type: "saving" }
+  | { type: "success"; message: string }
+  | { type: "error"; message: string };
+
+function formatDateInput(date: Date) {
+  return format(date, "yyyy-MM-dd");
+}
+
+export default function Home() {
+  const { user } = useAuth();
+  const amountInputRef = useRef<HTMLInputElement>(null);
+  const accounts = useAccountStore((state) => state.items.filter((account) => account.isActive));
+  const accountsLoading = useAccountStore((state) => state.isLoading);
+  const categoriesAll = useCategoryStore((state) => state.items);
+  const categories = categoriesAll.filter((category) => category.isActive);
+  const categoriesLoading = useCategoryStore((state) => state.isLoading);
+  const transactions = useTransactionStore((state) => state.items);
+  const addTransaction = useTransactionStore((state) => state.addTransaction);
+
+  const [amount, setAmount] = useState("");
+  const [occurredAt, setOccurredAt] = useState(() => formatDateInput(new Date()));
+  const [accountId, setAccountId] = useState<string>("");
+  const [memo, setMemo] = useState("");
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
+  const [status, setStatus] = useState<FormStatus>({ type: "idle" });
+
+  const categoryNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const category of categoriesAll) {
+      map.set(category.id, category.name);
+    }
+    return map;
+  }, [categoriesAll]);
+
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat("ja-JP", { style: "currency", currency: "JPY", maximumFractionDigits: 0 }),
+    []
+  );
+
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat("ja-JP", { month: "short", day: "numeric" }),
+    []
+  );
+
+  useEffect(() => {
+    if (!accountId && accounts.length > 0) {
+      setAccountId(accounts[0].id);
+    }
+  }, [accountId, accounts]);
+
+  useEffect(() => {
+    if (status.type !== "success") return;
+    const timer = window.setTimeout(() => {
+      setStatus({ type: "idle" });
+    }, 3000);
+    return () => window.clearTimeout(timer);
+  }, [status]);
+
+  const hasAccounts = accounts.length > 0;
+  const isSaving = status.type === "saving";
+  const amountValue = Number.parseInt(amount, 10);
+  const isAmountValid = Number.isFinite(amountValue) && amountValue > 0;
+  const canSubmit =
+    !!user && hasAccounts && !!accountId && isAmountValid && !isSaving && !accountsLoading;
+
+  const recentTransactions = useMemo(() => transactions.slice(0, 5), [transactions]);
+
+  function resetStatus() {
+    setStatus((prev) => {
+      if (prev.type === "success" || prev.type === "error") {
+        return { type: "idle" };
+      }
+      return prev;
+    });
+  }
+
+  function handleCategoryToggle(categoryId: string) {
+    setSelectedCategoryIds((prev) =>
+      prev.includes(categoryId) ? prev.filter((id) => id !== categoryId) : [...prev, categoryId]
+    );
+    resetStatus();
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!user || !hasAccounts) return;
+
+    if (!isAmountValid) {
+      setStatus({ type: "error", message: "金額は1円以上の整数で入力してください" });
+      return;
+    }
+
+    if (!accountId) {
+      setStatus({ type: "error", message: "支払アカウントを選択してください" });
+      return;
+    }
+
+    setStatus({ type: "saving" });
+    try {
+      await addTransaction({
+        userId: user.id,
+        accountId,
+        amount: amountValue,
+        occurredAt,
+        memo: memo.trim() || undefined,
+        categoryIds: selectedCategoryIds.length > 0 ? selectedCategoryIds : undefined,
+      });
+
+      setStatus({ type: "success", message: "保存しました (オフライン時は後で同期します)" });
+      setAmount("");
+      setMemo("");
+      setSelectedCategoryIds([]);
+      requestAnimationFrame(() => {
+        amountInputRef.current?.focus();
+      });
+    } catch (error) {
+      console.error("Failed to add transaction", error);
+      setStatus({
+        type: "error",
+        message: error instanceof Error ? error.message : "保存に失敗しました",
+      });
+    }
+  }
+
   return (
-    <div>
-      <h1>ホーム</h1>
-      <p>ここに即入力フォームを配置します。</p>
+    <div className="home">
+      <section className="home__layout">
+        <form className="home__form" onSubmit={handleSubmit}>
+          <header className="home__header">
+            <h1 className="home__title">即入力</h1>
+            <p className="home__subtitle">金額とカテゴリを素早く記録します。N キーでこのフォームにフォーカスできます。</p>
+          </header>
+
+          <div className="home__field">
+            <label className="home__label" htmlFor="amount">
+              金額 (円)
+            </label>
+            <input
+              id="amount"
+              name="amount"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              required
+              ref={amountInputRef}
+              className="home__input"
+              value={amount}
+              onChange={(event) => {
+                setAmount(event.currentTarget.value.replace(/[^0-9]/g, ""));
+                resetStatus();
+              }}
+            />
+          </div>
+
+          <div className="home__two-column">
+            <div className="home__field">
+              <label className="home__label" htmlFor="occurred-at">
+                日付
+              </label>
+              <input
+                id="occurred-at"
+                name="occurredAt"
+                type="date"
+                required
+                className="home__input"
+                value={occurredAt}
+                onChange={(event) => {
+                  setOccurredAt(event.currentTarget.value);
+                  resetStatus();
+                }}
+              />
+            </div>
+            <div className="home__field">
+              <label className="home__label" htmlFor="account">
+                支払アカウント
+              </label>
+              <select
+                id="account"
+                name="accountId"
+                required
+                className="home__input"
+                value={accountId}
+                onChange={(event) => {
+                  setAccountId(event.currentTarget.value);
+                  resetStatus();
+                }}
+                disabled={!hasAccounts}
+              >
+                {!hasAccounts ? <option value="">アカウントがありません</option> : null}
+                {accounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name}
+                  </option>
+                ))}
+              </select>
+              {!hasAccounts && !accountsLoading ? (
+                <p className="home__hint" role="note">
+                  アカウントが未設定です。先に設定画面で登録してください。
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="home__field">
+            <label className="home__label" htmlFor="memo">
+              メモ (任意)
+            </label>
+            <input
+              id="memo"
+              name="memo"
+              type="text"
+              className="home__input"
+              value={memo}
+              onChange={(event) => {
+                setMemo(event.currentTarget.value);
+                resetStatus();
+              }}
+            />
+          </div>
+
+          <fieldset className="home__field home__field--categories">
+            <legend className="home__label">カテゴリ (複数選択可・均等按分)</legend>
+            {categoriesLoading ? (
+              <p className="home__hint">読み込み中…</p>
+            ) : categories.length === 0 ? (
+              <p className="home__hint">カテゴリがまだありません。デフォルトカテゴリを同期してください。</p>
+            ) : (
+              <div className="home__categories">
+                {categories.map((category) => {
+                  const checked = selectedCategoryIds.includes(category.id);
+                  return (
+                    <label key={category.id} className={`home__category${checked ? " home__category--selected" : ""}`}>
+                      <input
+                        type="checkbox"
+                        value={category.id}
+                        checked={checked}
+                        onChange={() => handleCategoryToggle(category.id)}
+                      />
+                      <span>{category.name}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </fieldset>
+
+          <div className="home__actions">
+            <button type="submit" className="home__submit" disabled={!canSubmit}>
+              {isSaving ? "保存中…" : "保存"}
+            </button>
+            <span className="home__hint">Enter で保存できます</span>
+          </div>
+
+          {status.type === "success" ? (
+            <p className="home__status home__status--success" role="status">
+              {status.message}
+            </p>
+          ) : null}
+          {status.type === "error" ? (
+            <p className="home__status home__status--error" role="alert">
+              {status.message}
+            </p>
+          ) : null}
+        </form>
+
+        <section className="home__recent" aria-label="最近の入力">
+          <header className="home__recent-header">
+            <h2>最近の取引</h2>
+            <p className="home__recent-hint">最新5件を表示します。詳細は履歴タブへ。</p>
+          </header>
+
+          {recentTransactions.length === 0 ? (
+            <p className="home__empty">まだ取引がありません。入力するとここに表示されます。</p>
+          ) : (
+            <ul className="home__recent-list">
+              {recentTransactions.map((transaction) => (
+                <li key={transaction.id} className="home__transaction">
+                  <div className="home__transaction-meta">
+                    <span className="home__transaction-date">
+                      {dateFormatter.format(new Date(transaction.occurredAt))}
+                    </span>
+                    <span className="home__transaction-amount">
+                      {currencyFormatter.format(transaction.amount)}
+                    </span>
+                    {transaction.pendingSync ? (
+                      <span className="home__pending" role="status">
+                        未同期
+                      </span>
+                    ) : null}
+                  </div>
+                  {transaction.memo ? <p className="home__transaction-memo">{transaction.memo}</p> : null}
+                  {transaction.splits.length > 0 ? (
+                    <ul className="home__transaction-categories">
+                      {transaction.splits.map((split) => (
+                        <li key={split.id}>{categoryNameById.get(split.categoryId) ?? "カテゴリ不明"}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </section>
     </div>
   );
 }
+
+
+
+

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,74 @@
+﻿import { useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { supabase } from "../lib/supabase";
+import { useAuth } from "../lib/auth";
+
+export default function Login() {
+  const { session, isLoading } = useAuth();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<{ type: "idle" | "sending" | "sent" | "error"; message?: string }>({
+    type: "idle",
+  });
+
+  const from = (location.state as { from?: Location } | undefined)?.from?.pathname ?? "/";
+
+  if (!isLoading && session) {
+    return <Navigate to={from} replace />;
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus({ type: "sending" });
+    try {
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: `${window.location.origin}/`,
+        },
+      });
+      if (error) throw error;
+      setStatus({ type: "sent" });
+    } catch (error) {
+      console.error(error);
+      setStatus({
+        type: "error",
+        message: error instanceof Error ? error.message : "リンク送信に失敗しました",
+      });
+    }
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <h1>楽勘主義 ログイン</h1>
+        <p className="login-card__hint">許可されたメールアドレスにマジックリンクを送信します。</p>
+        <form className="login-form" onSubmit={handleSubmit}>
+          <label className="login-form__label">
+            メールアドレス
+            <input
+              className="login-form__input"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.currentTarget.value)}
+              placeholder="you@example.com"
+              required
+              autoFocus
+            />
+          </label>
+          <button type="submit" disabled={status.type === "sending"}>{status.type === "sending" ? "送信中…" : "マジックリンクを送信"}</button>
+        </form>
+        {status.type === "sent" ? (
+          <p className="login-card__success" role="status">
+            メールのリンクを確認してください。
+          </p>
+        ) : null}
+        {status.type === "error" ? (
+          <p className="login-card__error" role="alert">
+            {status.message}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,0 +1,8 @@
+﻿export default function Reports() {
+  return (
+    <div>
+      <h1>レポート</h1>
+      <p>月次・年次の可視化コンポーネントをここに実装します。</p>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,8 @@
+﻿export default function Settings() {
+  return (
+    <div>
+      <h1>設定</h1>
+      <p>アプリ全体の設定フォームをここに実装します。</p>
+    </div>
+  );
+}

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,8 +1,327 @@
-﻿export default function Transactions() {
+﻿import { useMemo, useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+import type { TransactionWithSplits as StoredTransaction } from "../lib/db";
+import { useAccountStore, useCategoryStore, useTransactionStore } from "../lib/store";
+
+type StatusFilter = "all" | "pending" | "synced";
+
+type FilterState = {
+  search: string;
+  accountId: string;
+  categoryId: string;
+  status: StatusFilter;
+  startDate: string;
+  endDate: string;
+};
+
+const DEFAULT_FILTERS: FilterState = {
+  search: "",
+  accountId: "",
+  categoryId: "",
+  status: "all",
+  startDate: "",
+  endDate: "",
+};
+
+export default function Transactions() {
+  const accounts = useAccountStore((state) => state.items);
+  const categories = useCategoryStore((state) => state.items);
+  const transactions = useTransactionStore((state) => state.items);
+  const isLoading = useTransactionStore((state) => state.isLoading);
+  const error = useTransactionStore((state) => state.error);
+
+  const [filters, setFilters] = useState<FilterState>(() => ({ ...DEFAULT_FILTERS }));
+
+  const accountNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const account of accounts) {
+      map.set(account.id, account.name);
+    }
+    return map;
+  }, [accounts]);
+
+  const categoryNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const category of categories) {
+      map.set(category.id, category.name);
+    }
+    return map;
+  }, [categories]);
+
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat("ja-JP", { style: "currency", currency: "JPY", maximumFractionDigits: 0 }),
+    []
+  );
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("ja-JP", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }),
+    []
+  );
+
+  const hasActiveFilters = useMemo(() => {
+    return (
+      filters.search.trim() !== "" ||
+      filters.accountId !== "" ||
+      filters.categoryId !== "" ||
+      filters.startDate !== "" ||
+      filters.endDate !== "" ||
+      filters.status !== "all"
+    );
+  }, [filters]);
+
+  const filteredTransactions = useMemo<StoredTransaction[]>(() => {
+    const searchTerm = filters.search.trim().toLowerCase();
+
+    return transactions.filter((transaction) => {
+      if (filters.accountId && transaction.accountId !== filters.accountId) {
+        return false;
+      }
+
+      if (filters.status === "pending" && !transaction.pendingSync) {
+        return false;
+      }
+
+      if (filters.status === "synced" && transaction.pendingSync) {
+        return false;
+      }
+
+      if (filters.startDate && transaction.occurredAt < filters.startDate) {
+        return false;
+      }
+
+      if (filters.endDate && transaction.occurredAt > filters.endDate) {
+        return false;
+      }
+
+      if (filters.categoryId) {
+        const hasCategory = transaction.splits.some((split) => split.categoryId === filters.categoryId);
+        if (!hasCategory) {
+          return false;
+        }
+      }
+
+      if (searchTerm) {
+        const memoText = transaction.memo?.toLowerCase() ?? "";
+        const accountName = accountNameById.get(transaction.accountId)?.toLowerCase() ?? "";
+        const categoryNames = transaction.splits
+          .map((split) => categoryNameById.get(split.categoryId)?.toLowerCase() ?? "")
+          .join(" ");
+        const amountText = transaction.amount.toString();
+        const haystack = `${memoText} ${accountName} ${categoryNames} ${amountText}`;
+        if (!haystack.includes(searchTerm)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [transactions, filters, accountNameById, categoryNameById]);
+
+  const limitedTransactions = useMemo<StoredTransaction[]>(() => filteredTransactions.slice(0, 200), [filteredTransactions]);
+
+  const totalAmount = useMemo(
+    () => filteredTransactions.reduce((sum, transaction) => sum + transaction.amount, 0),
+    [filteredTransactions]
+  );
+
+  const pendingCount = useMemo(
+    () => filteredTransactions.reduce((count, transaction) => count + (transaction.pendingSync ? 1 : 0), 0),
+    [filteredTransactions]
+  );
+
+  function handleFilterChange(event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    const { name, value } = event.currentTarget;
+    setFilters((prev) => ({ ...prev, [name]: value }));
+  }
+
+  function handleFiltersReset() {
+    setFilters(() => ({ ...DEFAULT_FILTERS }));
+  }
+
+  function handleFiltersSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+  }
+
   return (
-    <div>
-      <h1>取引一覧</h1>
-      <p>取引の検索・フィルタ・一覧表示をここに実装します。</p>
+    <div className="transactions">
+      <header className="transactions__header">
+        <h1>取引一覧</h1>
+        <p>ローカルに保存された取引を表示します。必要に応じて検索・フィルタを行ってください。</p>
+      </header>
+
+      <section className="transactions__summary">
+        <div className="transactions__summary-card" role="status" aria-live="polite">
+          <span className="transactions__summary-label">表示件数</span>
+          <strong className="transactions__summary-value">{filteredTransactions.length}</strong>
+        </div>
+        <div className="transactions__summary-card">
+          <span className="transactions__summary-label">合計金額</span>
+          <strong className="transactions__summary-value">{currencyFormatter.format(totalAmount)}</strong>
+        </div>
+        <div className="transactions__summary-card">
+          <span className="transactions__summary-label">未同期</span>
+          <strong className="transactions__summary-value">{pendingCount}</strong>
+        </div>
+      </section>
+
+      <form className="transactions__filters" onSubmit={handleFiltersSubmit}>
+        <div className="transactions__filters-row">
+          <label className="transactions__filters-group">
+            <span className="transactions__filters-label">キーワード</span>
+            <input
+              type="search"
+              name="search"
+              className="home__input"
+              placeholder="メモ / カテゴリ / 金額"
+              value={filters.search}
+              onChange={handleFilterChange}
+            />
+          </label>
+          <label className="transactions__filters-group">
+            <span className="transactions__filters-label">支払アカウント</span>
+            <select name="accountId" className="home__input" value={filters.accountId} onChange={handleFilterChange}>
+              <option value="">すべて</option>
+              {accounts.map((account) => (
+                <option key={account.id} value={account.id}>
+                  {account.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="transactions__filters-group">
+            <span className="transactions__filters-label">カテゴリ</span>
+            <select name="categoryId" className="home__input" value={filters.categoryId} onChange={handleFilterChange}>
+              <option value="">すべて</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="transactions__filters-row">
+          <label className="transactions__filters-group">
+            <span className="transactions__filters-label">開始日</span>
+            <input
+              type="date"
+              name="startDate"
+              className="home__input"
+              value={filters.startDate}
+              onChange={handleFilterChange}
+            />
+          </label>
+          <label className="transactions__filters-group">
+            <span className="transactions__filters-label">終了日</span>
+            <input
+              type="date"
+              name="endDate"
+              className="home__input"
+              value={filters.endDate}
+              onChange={handleFilterChange}
+            />
+          </label>
+          <label className="transactions__filters-group">
+            <span className="transactions__filters-label">同期状態</span>
+            <select name="status" className="home__input" value={filters.status} onChange={handleFilterChange}>
+              <option value="all">すべて</option>
+              <option value="pending">未同期のみ</option>
+              <option value="synced">同期済のみ</option>
+            </select>
+          </label>
+          <div className="transactions__filters-actions">
+            <button type="submit" className="transactions__filters-apply">
+              適用
+            </button>
+            <button type="button" className="transactions__filters-reset" onClick={handleFiltersReset} disabled={!hasActiveFilters}>
+              クリア
+            </button>
+          </div>
+        </div>
+      </form>
+
+      {error ? (
+        <p className="transactions__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {isLoading ? (
+        <p className="transactions__loading" role="status" aria-live="polite">
+          読み込み中…
+        </p>
+      ) : null}
+
+      {!isLoading && limitedTransactions.length === 0 ? (
+        <p className="transactions__empty">
+          {hasActiveFilters ? "条件に一致する取引が見つかりませんでした" : "まだ取引がありません。ホーム画面から入力してください。"}
+        </p>
+      ) : null}
+
+      {limitedTransactions.length > 0 ? (
+        <section className="transactions__list" aria-label="取引結果">
+          <div className="transactions__table-container">
+            <table className="transactions__table">
+              <thead>
+                <tr>
+                  <th scope="col">日付</th>
+                  <th scope="col">金額</th>
+                  <th scope="col">支払</th>
+                  <th scope="col">カテゴリ</th>
+                  <th scope="col">メモ</th>
+                  <th scope="col">状態</th>
+                </tr>
+              </thead>
+              <tbody>
+                {limitedTransactions.map((transaction) => {
+                  const categoriesLabel = transaction.splits.length
+                    ? transaction.splits
+                        .map((split) => categoryNameById.get(split.categoryId) ?? "カテゴリ不明")
+                        .join("、")
+                    : "未分類";
+                  const accountName = accountNameById.get(transaction.accountId) ?? "支払不明";
+                  return (
+                    <tr key={transaction.id}>
+                      <td data-title="日付">{dateFormatter.format(new Date(transaction.occurredAt))}</td>
+                      <td data-title="金額" className="transactions__cell--amount">
+                        {currencyFormatter.format(transaction.amount)}
+                      </td>
+                      <td data-title="支払">{accountName}</td>
+                      <td data-title="カテゴリ">
+                        <span className="transactions__categories" title={categoriesLabel}>
+                          {categoriesLabel}
+                        </span>
+                      </td>
+                      <td data-title="メモ" className="transactions__cell--memo">
+                        {transaction.memo ? transaction.memo : <span className="transactions__memo-placeholder">—</span>}
+                      </td>
+                      <td data-title="状態">
+                        {transaction.pendingSync ? (
+                          <span className="transactions__badge transactions__badge--pending" role="status">
+                            未同期
+                          </span>
+                        ) : (
+                          <span className="transactions__badge transactions__badge--synced">同期済</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {filteredTransactions.length > limitedTransactions.length ? (
+            <p className="transactions__note" role="note">
+              {limitedTransactions.length}件まで表示しています（全{filteredTransactions.length}件）。フィルタで絞り込んでください。
+            </p>
+          ) : null}
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,0 +1,8 @@
+﻿export default function Transactions() {
+  return (
+    <div>
+      <h1>取引一覧</h1>
+      <p>取引の検索・フィルタ・一覧表示をここに実装します。</p>
+    </div>
+  );
+}


### PR DESCRIPTION
- 認証後にローカルキャッシュ初期化と同期を走らせる useAppBootstrap を追加 
  し、オフライン表示・再同期 UI を AppShell に実装                          
  - 支払アカウントの Dexie ミラーとストアを作成し、Home での即入力フォーム＋
  最近の取引リストをオフライン連携で構築                                    
  - 取引一覧をローカルデータから描画するフィルタ／サマリ付きテーブルに刷新  
  し、未同期バッジやページング告知を追加                                    
  - 共通スタイルを拡張し、ホーム・取引画面のレイアウト／カード／バッジを整備